### PR TITLE
Bw/design fixes2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
+import { AppContext } from '@edx/frontend-platform/react';
 import Footer from '@edx/frontend-component-footer';
 
-import { actions } from 'data/redux';
+import { thunkActions } from 'data/redux';
 import fakeData from 'data/services/lms/fakeData/courses';
 import LearnerDashboardHeader from 'containers/LearnerDashboardHeader';
 import Dashboard from 'containers/Dashboard';
@@ -14,16 +15,22 @@ import './App.scss';
 export const App = () => {
   const dispatch = useDispatch();
   // TODO: made development-only
+  const { authenticatedUser } = React.useContext(AppContext);
   React.useEffect(() => {
-    window.loadMockData = () => {
-      dispatch(actions.app.loadGlobalData(fakeData.globalData));
-      dispatch(actions.app.loadCourses({
-        courses: [
-          ...fakeData.courseRunData,
-          ...fakeData.entitlementData,
-        ],
-      }));
-    };
+    if (authenticatedUser?.administrator || process.env.NODE_ENV === 'development') {
+      window.loadEmptyData = () => {
+        dispatch(thunkActions.app.loadData({ ...fakeData.globalData, courses: [] }));
+      };
+      window.loadMockData = () => {
+        dispatch(thunkActions.app.loadData({
+          ...fakeData.globalData,
+          courses: [
+            ...fakeData.courseRunData,
+            ...fakeData.entitlementData,
+          ],
+        }));
+      };
+    }
   });
   return (
     <Router>

--- a/src/containers/CourseCard/components/CourseCardActions/BeginCourseButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/BeginCourseButton.test.jsx
@@ -1,36 +1,55 @@
 import { shallow } from 'enzyme';
 
+import { htmlProps } from 'testKeys';
 import { hooks } from 'data/redux';
 import BeginCourseButton from './BeginCourseButton';
 
 jest.mock('data/redux', () => ({
   hooks: {
-    useCardCourseRunData: jest.fn(),
-    useCardEnrollmentData: jest.fn(),
+    useCardCourseRunData: jest.fn(() => ({ homeUrl: 'home-url' })),
+    useCardEnrollmentData: jest.fn(() => ({ hasAccess: true })),
+    useMasqueradeData: jest.fn(() => ({ isMasquerading: false })),
   },
 }));
+
+let wrapper;
+const { homeUrl } = hooks.useCardCourseRunData();
 
 describe('BeginCourseButton', () => {
   const props = {
     cardId: 'cardId',
   };
-  hooks.useCardCourseRunData.mockReturnValue({
-    homeUrl: 'homeUrl',
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
   describe('snapshot', () => {
     test('renders default button when learner has access to the course', () => {
-      hooks.useCardEnrollmentData.mockReturnValueOnce({
-        hasAccess: true,
-      });
-      const wrapper = shallow(<BeginCourseButton {...props} />);
+      wrapper = shallow(<BeginCourseButton {...props} />);
       expect(wrapper).toMatchSnapshot();
+      expect(wrapper.prop(htmlProps.disabled)).toEqual(false);
+      expect(wrapper.prop(htmlProps.href)).toEqual(homeUrl);
     });
-    test('renders disabled button when learner does not have access to the course', () => {
-      hooks.useCardEnrollmentData.mockReturnValueOnce({
-        hasAccess: false,
+  });
+  describe('behavior', () => {
+    it('initializes course run data with cardId', () => {
+      wrapper = shallow(<BeginCourseButton {...props} />);
+      expect(hooks.useCardCourseRunData).toHaveBeenCalledWith(props.cardId);
+    });
+    it('initializes enrollment data with cardId', () => {
+      wrapper = shallow(<BeginCourseButton {...props} />);
+      expect(hooks.useCardEnrollmentData).toHaveBeenCalledWith(props.cardId);
+    });
+    describe('disabled states', () => {
+      test('learner does not have access', () => {
+        hooks.useCardEnrollmentData.mockReturnValueOnce({ hasAccess: false });
+        wrapper = shallow(<BeginCourseButton {...props} />);
+        expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
       });
-      const wrapper = shallow(<BeginCourseButton {...props} />);
-      expect(wrapper).toMatchSnapshot();
+      test('masquerading', () => {
+        hooks.useMasqueradeData.mockReturnValueOnce({ isMasquerading: true });
+        wrapper = shallow(<BeginCourseButton {...props} />);
+        expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
+      });
     });
   });
 });

--- a/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ResumeButton.test.jsx
@@ -1,56 +1,68 @@
 import { shallow } from 'enzyme';
 
+import { htmlProps } from 'testKeys';
 import { hooks } from 'data/redux';
 import ResumeButton from './ResumeButton';
 
 jest.mock('data/redux', () => ({
   hooks: {
-    useCardCourseRunData: jest.fn(),
-    useCardEnrollmentData: jest.fn(),
+    useCardCourseRunData: jest.fn(() => ({ resumeUrl: 'resumeUrl' })),
+    useCardEnrollmentData: jest.fn(() => ({
+      hasAccess: true,
+      isAudit: true,
+      isAuditAccessExpired: false,
+    })),
+    useMasqueradeData: jest.fn(() => ({ isMasquerading: false })),
   },
 }));
+
+const { resumeUrl } = hooks.useCardCourseRunData();
 
 describe('ResumeButton', () => {
   const props = {
     cardId: 'cardId',
   };
-  hooks.useCardCourseRunData.mockReturnValue({
-    resumeUrl: 'resumeUrl',
-  });
   describe('snapshot', () => {
     test('renders default button when learner has access to the course', () => {
-      hooks.useCardEnrollmentData.mockReturnValueOnce({
-        hasAccess: true,
-      });
       const wrapper = shallow(<ResumeButton {...props} />);
       expect(wrapper).toMatchSnapshot();
-    });
-    test('renders disabled button when learner does not have access to the course', () => {
-      hooks.useCardEnrollmentData.mockReturnValueOnce({
-        hasAccess: false,
-      });
-      const wrapper = shallow(<ResumeButton {...props} />);
-      expect(wrapper).toMatchSnapshot();
+      expect(wrapper.prop(htmlProps.disabled)).toEqual(false);
+      expect(wrapper.prop(htmlProps.href)).toEqual(resumeUrl);
     });
   });
   describe('behavior', () => {
-    it('renders disabled button when audit access expired', () => {
-      hooks.useCardEnrollmentData.mockReturnValueOnce({
-        hasAccess: true,
-        isAudit: true,
-        isAuditAccessExpired: true,
-      });
-      const wrapper = shallow(<ResumeButton {...props} />);
-      expect(wrapper.prop('disabled')).toEqual(true);
+    it('initializes course run data based on cardId', () => {
+      shallow(<ResumeButton {...props} />);
+      expect(hooks.useCardCourseRunData).toHaveBeenCalledWith(props.cardId);
     });
-    it('renders enabled button when audit access not expired', () => {
-      hooks.useCardEnrollmentData.mockReturnValueOnce({
-        hasAccess: true,
-        isAudit: true,
-        isAuditAccessExpired: false,
+    it('initializes course enrollment data based on cardId', () => {
+      shallow(<ResumeButton {...props} />);
+      expect(hooks.useCardEnrollmentData).toHaveBeenCalledWith(props.cardId);
+    });
+    describe('disabled states', () => {
+      test('masquerading', () => {
+        hooks.useMasqueradeData.mockReturnValueOnce({ isMasquerading: true });
+        const wrapper = shallow(<ResumeButton {...props} />);
+        expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
       });
-      const wrapper = shallow(<ResumeButton {...props} />);
-      expect(wrapper.prop('disabled')).toEqual(false);
+      test('learner does not have access', () => {
+        hooks.useCardEnrollmentData.mockReturnValueOnce({
+          hasAccess: false,
+          isAudit: true,
+          isAuditAccessExpired: false,
+        });
+        const wrapper = shallow(<ResumeButton {...props} />);
+        expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
+      });
+      test('audit access expired', () => {
+        hooks.useCardEnrollmentData.mockReturnValueOnce({
+          hasAccess: true,
+          isAudit: true,
+          isAuditAccessExpired: true,
+        });
+        const wrapper = shallow(<ResumeButton {...props} />);
+        expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
+      });
     });
   });
 });

--- a/src/containers/CourseCard/components/CourseCardActions/SelectSessionButton.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/SelectSessionButton.jsx
@@ -9,7 +9,6 @@ import { hooks } from 'data/redux';
 import messages from './messages';
 
 export const SelectSessionButton = ({ cardId }) => {
-  const { resumeUrl } = hooks.useCardCourseRunData(cardId);
   const { hasAccess } = hooks.useCardEnrollmentData(cardId);
   const { canChange, hasSessions } = hooks.useCardEntitlementData(cardId);
   const { isMasquerading } = hooks.useMasqueradeData();
@@ -20,8 +19,6 @@ export const SelectSessionButton = ({ cardId }) => {
     <Button
       disabled={isMasquerading || !hasAccess || (!canChange || !hasSessions)}
       onClick={openSessionModal}
-      as="a"
-      href={resumeUrl}
     >
       {formatMessage(messages.resume)}
     </Button>

--- a/src/containers/CourseCard/components/CourseCardActions/UpgradeButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/UpgradeButton.test.jsx
@@ -1,12 +1,14 @@
 import { shallow } from 'enzyme';
 
+import { htmlProps } from 'testKeys';
 import { hooks } from 'data/redux';
 import UpgradeButton from './UpgradeButton';
 
 jest.mock('data/redux', () => ({
   hooks: {
+    useMasqueradeData: jest.fn(() => ({ isMasquerading: false })),
     useCardCourseRunData: jest.fn(),
-    useCardEnrollmentData: jest.fn(),
+    useCardEnrollmentData: jest.fn(() => ({ canUpgrade: true })),
   },
 }));
 
@@ -18,14 +20,21 @@ describe('UpgradeButton', () => {
   hooks.useCardCourseRunData.mockReturnValue({ upgradeUrl });
   describe('snapshot', () => {
     test('can upgrade', () => {
-      hooks.useCardEnrollmentData.mockReturnValueOnce({ canUpgrade: true });
       const wrapper = shallow(<UpgradeButton {...props} />);
       expect(wrapper).toMatchSnapshot();
+      expect(wrapper.prop(htmlProps.disabled)).toEqual(false);
     });
     test('cannot upgrade', () => {
       hooks.useCardEnrollmentData.mockReturnValueOnce({ canUpgrade: false });
       const wrapper = shallow(<UpgradeButton {...props} />);
       expect(wrapper).toMatchSnapshot();
+      expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
+    });
+    test('masquerading', () => {
+      hooks.useMasqueradeData.mockReturnValueOnce({ isMasquerading: true });
+      const wrapper = shallow(<UpgradeButton {...props} />);
+      expect(wrapper).toMatchSnapshot();
+      expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
     });
   });
 });

--- a/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.test.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/ViewCourseButton.test.jsx
@@ -1,49 +1,53 @@
 import { shallow } from 'enzyme';
 
+import { htmlProps } from 'testKeys';
 import { hooks } from 'data/redux';
 import ViewCourseButton from './ViewCourseButton';
 
 jest.mock('data/redux', () => ({
   hooks: {
-    useCardCourseRunData: jest.fn(),
-    useCardEnrollmentData: jest.fn(),
-    useCardEntitlementData: jest.fn(),
+    useCardCourseRunData: jest.fn(() => ({ marketingUrl: 'marketing-url' })),
+    useCardEnrollmentData: jest.fn(() => ({ hasAccess: true })),
+    useCardEntitlementData: jest.fn(() => ({ isEntitlement: false, isExpired: false })),
+    useMasqueradeData: jest.fn(() => ({ isMasquerading: false })),
   },
 }));
+
+let wrapper;
 
 describe('ViewCourseButton', () => {
   const props = {
     cardId: 'cardId',
   };
-  const marketingUrl = 'marketingUrl';
-  hooks.useCardCourseRunData.mockReturnValue({ marketingUrl });
-  const createWrapper = ({ hasAccess, isEntitlement, isExpired }) => {
-    hooks.useCardEnrollmentData.mockReturnValueOnce({ hasAccess });
-    hooks.useCardEntitlementData.mockReturnValueOnce({ isEntitlement, isExpired });
-    return shallow(<ViewCourseButton {...props} />);
-  };
+  const { marketingUrl } = hooks.useCardCourseRunData();
   describe('snapshot', () => {
     test('default button', () => {
-      const wrapper = createWrapper({ hasAccess: true, isEntitlement: false, isExpired: false });
+      wrapper = shallow(<ViewCourseButton {...props} />);
       expect(wrapper).toMatchSnapshot();
-    });
-    test('disabled button', () => {
-      const wrapper = createWrapper({ hasAccess: false, isEntitlement: false, isExpired: false });
-      expect(wrapper).toMatchSnapshot();
+      expect(wrapper.prop(htmlProps.disabled)).toEqual(false);
+      expect(wrapper.prop(htmlProps.href)).toEqual(marketingUrl);
     });
   });
   describe('behavior', () => {
-    it('disabled button without access', () => {
-      const wrapper = createWrapper({ hasAccess: false, isEntitlement: false, isExpired: false });
-      expect(wrapper.prop('disabled')).toEqual(true);
-    });
-    it('disabled button with access', () => {
-      const wrapper = createWrapper({ hasAccess: true, isEntitlement: true, isExpired: true });
-      expect(wrapper.prop('disabled')).toEqual(true);
-    });
-    it('enabled button', () => {
-      const wrapper = createWrapper({ hasAccess: true, isEntitlement: false, isExpired: false });
-      expect(wrapper.prop('disabled')).toEqual(false);
+    describe('disabled states', () => {
+      test('learner does not have access', () => {
+        hooks.useCardEnrollmentData.mockReturnValueOnce({ hasAccess: false });
+        wrapper = shallow(<ViewCourseButton {...props} />);
+        expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
+      });
+      test('expired entitlement', () => {
+        hooks.useCardEntitlementData.mockReturnValueOnce({
+          isEntitlement: true,
+          isExpired: true,
+        });
+        wrapper = shallow(<ViewCourseButton {...props} />);
+        expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
+      });
+      test('masquerading', () => {
+        hooks.useMasqueradeData.mockReturnValueOnce({ isMasquerading: true });
+        wrapper = shallow(<ViewCourseButton {...props} />);
+        expect(wrapper.prop(htmlProps.disabled)).toEqual(true);
+      });
     });
   });
 });

--- a/src/containers/CourseCard/components/CourseCardActions/__snapshots__/BeginCourseButton.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardActions/__snapshots__/BeginCourseButton.test.jsx.snap
@@ -4,17 +4,7 @@ exports[`BeginCourseButton snapshot renders default button when learner has acce
 <Button
   as="a"
   disabled={false}
-  href="homeUrl"
->
-  Begin Course
-</Button>
-`;
-
-exports[`BeginCourseButton snapshot renders disabled button when learner does not have access to the course 1`] = `
-<Button
-  as="a"
-  disabled={true}
-  href="homeUrl"
+  href="home-url"
 >
   Begin Course
 </Button>

--- a/src/containers/CourseCard/components/CourseCardActions/__snapshots__/ResumeButton.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardActions/__snapshots__/ResumeButton.test.jsx.snap
@@ -3,16 +3,7 @@
 exports[`ResumeButton snapshot renders default button when learner has access to the course 1`] = `
 <Button
   as="a"
-  href="resumeUrl"
->
-  Resume
-</Button>
-`;
-
-exports[`ResumeButton snapshot renders disabled button when learner does not have access to the course 1`] = `
-<Button
-  as="a"
-  disabled={true}
+  disabled={false}
   href="resumeUrl"
 >
   Resume

--- a/src/containers/CourseCard/components/CourseCardActions/__snapshots__/SelectSessionButton.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardActions/__snapshots__/SelectSessionButton.test.jsx.snap
@@ -2,9 +2,16 @@
 
 exports[`SelectSessionButton snapshot renders default button 1`] = `
 <Button
-  as="a"
   disabled={false}
-  href="resumeUrl"
+  onClick={[MockFunction mockOpenSessionModal]}
+>
+  Resume
+</Button>
+`;
+
+exports[`SelectSessionButton snapshot renders disabled button if masquerading 1`] = `
+<Button
+  disabled={true}
   onClick={[MockFunction mockOpenSessionModal]}
 >
   Resume
@@ -13,9 +20,7 @@ exports[`SelectSessionButton snapshot renders default button 1`] = `
 
 exports[`SelectSessionButton snapshot renders disabled button when user does not have access to the course 1`] = `
 <Button
-  as="a"
   disabled={true}
-  href="resumeUrl"
   onClick={[MockFunction mockOpenSessionModal]}
 >
   Resume

--- a/src/containers/CourseCard/components/CourseCardActions/__snapshots__/UpgradeButton.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardActions/__snapshots__/UpgradeButton.test.jsx.snap
@@ -23,3 +23,15 @@ exports[`UpgradeButton snapshot cannot upgrade 1`] = `
   Upgrade
 </Button>
 `;
+
+exports[`UpgradeButton snapshot masquerading 1`] = `
+<Button
+  as="a"
+  disabled={true}
+  href="upgradeUrl"
+  iconBefore={[MockFunction icons.Locked]}
+  variant="outline-primary"
+>
+  Upgrade
+</Button>
+`;

--- a/src/containers/CourseCard/components/CourseCardActions/__snapshots__/ViewCourseButton.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardActions/__snapshots__/ViewCourseButton.test.jsx.snap
@@ -4,17 +4,7 @@ exports[`ViewCourseButton snapshot default button 1`] = `
 <Button
   as="a"
   disabled={false}
-  href="marketingUrl"
->
-  View Course
-</Button>
-`;
-
-exports[`ViewCourseButton snapshot disabled button 1`] = `
-<Button
-  as="a"
-  disabled={true}
-  href="marketingUrl"
+  href="marketing-url"
 >
   View Course
 </Button>

--- a/src/containers/CourseCard/components/RelatedProgramsBadge/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CourseCard/components/RelatedProgramsBadge/__snapshots__/index.test.jsx.snap
@@ -3,13 +3,17 @@
 exports[`RelatedProgramsBadge component snapshot: 3 programs 1`] = `
 <Fragment>
   <Button
-    className="pr-0 mr-0"
+    className="pl-0 mr-0"
     data-testid="RelatedProgramsBadge"
-    iconBefore={[MockFunction icons.Program]}
     onClick={[MockFunction useRelatedProgramsBadge.openModal]}
     size="sm"
     variant="tertiary"
   >
+    <Icon
+      className="mr-2 pr-0"
+      src={[MockFunction icons.Program]}
+    />
+     
     useRelatedProgramsBadge.programsMessage
   </Button>
   <RelatedProgramsModal

--- a/src/containers/CourseList/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CourseList/__snapshots__/index.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`CourseList snapshots with filters 1`] = `
     id="course-list-heading-container"
   >
     <h2
-      className="my-2"
+      className="my-3"
     >
       My Courses
     </h2>
@@ -30,14 +30,7 @@ exports[`CourseList snapshots with filters 1`] = `
   </div>
   <div
     className="d-flex flex-column flex-grow-1"
-  >
-    <Pagination
-      onPageSelect={[MockFunction setPageNumber]}
-      pageCount={1}
-      paginationLabel="Course List"
-      variant="secondary"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -49,7 +42,7 @@ exports[`CourseList snapshots with multiple courses and pages 1`] = `
     id="course-list-heading-container"
   >
     <h2
-      className="my-2"
+      className="my-3"
     >
       My Courses
     </h2>
@@ -76,6 +69,7 @@ exports[`CourseList snapshots with multiple courses and pages 1`] = `
       key="baz"
     />
     <Pagination
+      className="mx-auto"
       onPageSelect={[MockFunction setPageNumber]}
       pageCount={3}
       paginationLabel="Course List"
@@ -93,7 +87,7 @@ exports[`CourseList snapshots with no filters 1`] = `
     id="course-list-heading-container"
   >
     <h2
-      className="my-2"
+      className="my-3"
     >
       My Courses
     </h2>
@@ -106,13 +100,6 @@ exports[`CourseList snapshots with no filters 1`] = `
   </div>
   <div
     className="d-flex flex-column flex-grow-1"
-  >
-    <Pagination
-      onPageSelect={[MockFunction setPageNumber]}
-      pageCount={1}
-      paginationLabel="Course List"
-      variant="secondary"
-    />
-  </div>
+  />
 </div>
 `;

--- a/src/containers/CourseList/hooks.js
+++ b/src/containers/CourseList/hooks.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { useCheckboxSetValues } from '@edx/paragon';
 
 import { StrictDict } from 'utils';
-import { hooks as appHooks } from 'data/redux';
+import { actions, hooks as appHooks } from 'data/redux';
 import { ListPageSize, SortKeys } from 'data/constants/app';
 
 import * as module from './hooks';
@@ -13,19 +13,21 @@ export const state = StrictDict({
   sortBy: (val) => React.useState(val), // eslint-disable-line
 });
 
-export const useCourseListData = () => {
-  const [pageNumber, setPageNumber] = module.state.pageNumber(1);
-  const [sortBy, setSortBy] = module.state.sortBy(SortKeys.title);
+export const useCourseListData = (dispatch) => {
+  const pageNumber = appHooks.usePageNumber();
   const [filters, setFilters] = useCheckboxSetValues([]);
+  const [sortBy, setSortBy] = module.state.sortBy(SortKeys.title);
+
   const { numPages, visible } = appHooks.useCurrentCourseList({
     sortBy,
     isAscending: true,
     filters,
-    pageNumber,
     pageSize: ListPageSize,
   });
   const handleRemoveFilter = (filter) => () => setFilters.remove(filter);
+  const setPageNumber = (value) => dispatch(actions.app.setPageNumber(value));
   return {
+    pageNumber,
     numPages,
     setPageNumber,
     visibleList: visible,

--- a/src/containers/CourseList/hooks.js
+++ b/src/containers/CourseList/hooks.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 
 import { useCheckboxSetValues } from '@edx/paragon';
 
@@ -9,11 +10,11 @@ import { ListPageSize, SortKeys } from 'data/constants/app';
 import * as module from './hooks';
 
 export const state = StrictDict({
-  pageNumber: (val) => React.useState(val), // eslint-disable-line
   sortBy: (val) => React.useState(val), // eslint-disable-line
 });
 
-export const useCourseListData = (dispatch) => {
+export const useCourseListData = () => {
+  const dispatch = useDispatch();
   const pageNumber = appHooks.usePageNumber();
   const [filters, setFilters] = useCheckboxSetValues([]);
   const [sortBy, setSortBy] = module.state.sortBy(SortKeys.title);

--- a/src/containers/CourseList/index.jsx
+++ b/src/containers/CourseList/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Pagination } from '@edx/paragon';
@@ -14,13 +15,14 @@ import './index.scss';
 
 export const CourseList = () => {
   const { formatMessage } = useIntl();
+  const dispatch = useDispatch();
   const {
     filterOptions,
     setPageNumber,
     numPages,
     showFilters,
     visibleList,
-  } = useCourseListData();
+  } = useCourseListData(dispatch);
   return (
     <div className="course-list-container">
       <div id="course-list-heading-container">

--- a/src/containers/CourseList/index.jsx
+++ b/src/containers/CourseList/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Pagination } from '@edx/paragon';
@@ -15,14 +14,13 @@ import './index.scss';
 
 export const CourseList = () => {
   const { formatMessage } = useIntl();
-  const dispatch = useDispatch();
   const {
     filterOptions,
     setPageNumber,
     numPages,
     showFilters,
     visibleList,
-  } = useCourseListData(dispatch);
+  } = useCourseListData();
   return (
     <div className="course-list-container">
       <div id="course-list-heading-container">

--- a/src/containers/EmptyCourse/SuggestedCourses/__snapshots__/index.test.jsx.snap
+++ b/src/containers/EmptyCourse/SuggestedCourses/__snapshots__/index.test.jsx.snap
@@ -21,14 +21,20 @@ exports[`SuggestedCourses snapshot has 3 suggested courses 1`] = `
         srcAlt="Course image banner"
       />
       <Card.Header
+        className="mb-2"
         title="Suggested course 1"
       />
+      <Card.Body
+        className="h-100"
+      />
       <Card.Footer>
-        <Button
-          as="a"
-        >
-          View Course
-        </Button>
+        <ActionRow>
+          <Button
+            as="a"
+          >
+            View Course
+          </Button>
+        </ActionRow>
       </Card.Footer>
     </Card>
     <Card
@@ -40,14 +46,20 @@ exports[`SuggestedCourses snapshot has 3 suggested courses 1`] = `
         srcAlt="Course image banner"
       />
       <Card.Header
+        className="mb-2"
         title="Suggested course 2"
       />
+      <Card.Body
+        className="h-100"
+      />
       <Card.Footer>
-        <Button
-          as="a"
-        >
-          View Course
-        </Button>
+        <ActionRow>
+          <Button
+            as="a"
+          >
+            View Course
+          </Button>
+        </ActionRow>
       </Card.Footer>
     </Card>
     <Card
@@ -59,14 +71,20 @@ exports[`SuggestedCourses snapshot has 3 suggested courses 1`] = `
         srcAlt="Course image banner"
       />
       <Card.Header
+        className="mb-2"
         title="Suggested course 3"
       />
+      <Card.Body
+        className="h-100"
+      />
       <Card.Footer>
-        <Button
-          as="a"
-        >
-          View Course
-        </Button>
+        <ActionRow>
+          <Button
+            as="a"
+          >
+            View Course
+          </Button>
+        </ActionRow>
       </Card.Footer>
     </Card>
   </div>

--- a/src/containers/EmptyCourse/SuggestedCourses/index.jsx
+++ b/src/containers/EmptyCourse/SuggestedCourses/index.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { ActionRow, Card, Button, Container } from '@edx/paragon';
+import {
+  ActionRow,
+  Card,
+  Button,
+  Container,
+} from '@edx/paragon';
 import { hooks as appHooks } from 'data/redux';
 
 import messages from './messages';

--- a/src/containers/EmptyCourse/SuggestedCourses/index.jsx
+++ b/src/containers/EmptyCourse/SuggestedCourses/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { Card, Button, Container } from '@edx/paragon';
+import { ActionRow, Card, Button, Container } from '@edx/paragon';
 import { hooks as appHooks } from 'data/redux';
 
 import messages from './messages';
@@ -20,9 +20,12 @@ export const SuggestedCourses = () => {
               src={course.bannerImgSrc}
               srcAlt={formatMessage(messages.courseImageAlt)}
             />
-            <Card.Header title={course.courseName} />
+            <Card.Header title={course.courseName} className="mb-2" />
+            <Card.Body className="h-100" />
             <Card.Footer>
-              <Button as="a">{formatMessage(messages.viewCourseButton)}</Button>
+              <ActionRow>
+                <Button as="a">{formatMessage(messages.viewCourseButton)}</Button>
+              </ActionRow>
             </Card.Footer>
           </Card>
         ))}

--- a/src/containers/LearnerDashboardHeader/__snapshots__/AuthenticatedUserDropdown.test.jsx.snap
+++ b/src/containers/LearnerDashboardHeader/__snapshots__/AuthenticatedUserDropdown.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`AuthenticatedUserDropdown snapshots with enterprise dashboard 1`] = `
 <Dropdown
   className="user-dropdown"
+  variant="light"
 >
   <Dropdown.Toggle
     id="user"
@@ -54,7 +55,9 @@ exports[`AuthenticatedUserDropdown snapshots with enterprise dashboard 1`] = `
     >
       Account
     </Dropdown.Item>
-    <Dropdown.Item>
+    <Dropdown.Item
+      href="http://localhost:18000/support"
+    >
       Help
     </Dropdown.Item>
     <Dropdown.Divider />
@@ -70,6 +73,7 @@ exports[`AuthenticatedUserDropdown snapshots with enterprise dashboard 1`] = `
 exports[`AuthenticatedUserDropdown snapshots without enterprise dashboard and expanded 1`] = `
 <Dropdown
   className="user-dropdown"
+  variant="dark"
 >
   <Dropdown.Toggle
     id="user"
@@ -107,7 +111,9 @@ exports[`AuthenticatedUserDropdown snapshots without enterprise dashboard and ex
     >
       Account
     </Dropdown.Item>
-    <Dropdown.Item>
+    <Dropdown.Item
+      href="http://localhost:18000/support"
+    >
       Help
     </Dropdown.Item>
     <Dropdown.Divider />

--- a/src/containers/RelatedProgramsModal/__snapshots__/index.test.jsx.snap
+++ b/src/containers/RelatedProgramsModal/__snapshots__/index.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`RelatedProgramsModal snapshot: closed 1`] = `
     className="programs-header p-0"
   />
   <ModalDialog.Body
-    className="pl-0 overflow-hidden"
+    className="pl-0 overflow-scroll"
   >
     <p>
       Are you looking to expand your knowledge?  Enrolling in a Program lets you take a series of courses in the subject that you're interested in
@@ -105,7 +105,7 @@ exports[`RelatedProgramsModal snapshot: open 1`] = `
     className="programs-header p-0"
   />
   <ModalDialog.Body
-    className="pl-0 overflow-hidden"
+    className="pl-0 overflow-scroll"
   >
     <p>
       Are you looking to expand your knowledge?  Enrolling in a Program lets you take a series of courses in the subject that you're interested in

--- a/src/containers/RelatedProgramsModal/components/ProgramCard.jsx
+++ b/src/containers/RelatedProgramsModal/components/ProgramCard.jsx
@@ -25,6 +25,8 @@ export const ProgramCard = ({ data }) => {
     <Card
       className="program-card mx-auto bg-primary-500 text-white mb-3.5 pb-3.5"
       style={{ width: '18rem', color: 'white' }}
+      as="a"
+      href={data.programUrl}
     >
       <Card.ImageCap
         className="program-card-banner"

--- a/src/containers/RelatedProgramsModal/components/__snapshots__/ProgramCard.test.jsx.snap
+++ b/src/containers/RelatedProgramsModal/components/__snapshots__/ProgramCard.test.jsx.snap
@@ -2,7 +2,9 @@
 
 exports[`RelatedProgramsModal ProgramCard snapshot 1`] = `
 <Card
+  as="a"
   className="program-card mx-auto bg-primary-500 text-white mb-3.5 pb-3.5"
+  href="props.data.programUrl"
   style={
     Object {
       "color": "white",

--- a/src/containers/RelatedProgramsModal/index.jsx
+++ b/src/containers/RelatedProgramsModal/index.jsx
@@ -37,7 +37,7 @@ export const RelatedProgramsModal = ({
       <ModalDialog.Header as="h4" className="programs-header p-0">
         {courseName}
       </ModalDialog.Header>
-      <ModalDialog.Body className="pl-0 overflow-hidden">
+      <ModalDialog.Body className="pl-0 overflow-scroll">
         <p>{formatMessage(messages.description)}</p>
         <Container>
           <Row>

--- a/src/containers/WidgetSidebar/__snapshots__/index.test.jsx.snap
+++ b/src/containers/WidgetSidebar/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`WidgetSidebar snapshots default 1`] = `
 <div
-  className="widget-sidebar"
+  className="widget-sidebar px-2 mt-5 pt-3"
 >
   <div
     className="d-flex"
@@ -21,10 +21,26 @@ exports[`WidgetSidebar snapshots default 1`] = `
           Looking for a new challenge?
         </h4>
         <Hyperlink
+          className="d-flex"
           destination="#"
           variant="brand"
         >
-          Explore courses
+          <format-message-function
+            message={
+              Object {
+                "defaultMessage": "Find a course {arrow}",
+                "description": "Button to explore more courses",
+                "id": "WidgetSidebar.findCoursesButton",
+              }
+            }
+            values={
+              Object {
+                "arrow": <Icon
+                  className="mx-1"
+                />,
+              }
+            }
+          />
         </Hyperlink>
       </Card.Body>
     </Card>

--- a/src/data/redux/app/reducer.js
+++ b/src/data/redux/app/reducer.js
@@ -1,12 +1,14 @@
-import { StrictDict } from 'utils';
 import { createSlice } from '@reduxjs/toolkit';
 
+import { StrictDict } from 'utils';
+
 const initialState = {
+  pageNumber: 1,
   enrollments: [],
   courseData: {},
   entitlement: [],
   emailConfirmation: {},
-  enterpriseDashboards: {},
+  enterpriseDashboard: {},
   platformSettings: {},
   suggestedCourses: [],
   filterState: {},
@@ -41,6 +43,7 @@ const app = createSlice({
       ...state,
       selectSessionModal: { cardId: payload },
     }),
+    setPageNumber: (state, { payload }) => ({ ...state, pageNumber: payload }),
   },
 });
 

--- a/src/data/redux/app/selectors.js
+++ b/src/data/redux/app/selectors.js
@@ -17,6 +17,7 @@ export const simpleSelectors = {
   emailConfirmation: mkSimpleSelector(app => app.emailConfirmation),
   enterpriseDashboard: mkSimpleSelector(app => app.enterpriseDashboard),
   selectSessionModal: mkSimpleSelector(app => app.selectSessionModal),
+  pageNumber: mkSimpleSelector(app => app.pageNumber),
 };
 
 export const numCourses = createSelector(
@@ -130,9 +131,9 @@ export const currentList = (state, {
   sortBy,
   isAscending,
   filters,
-  pageNumber,
   pageSize,
 }) => {
+  const pageNumber = module.simpleSelectors.pageNumber(state);
   let list = Object.values(module.simpleSelectors.courseData(state));
   const hasFilter = filters.reduce((obj, filter) => ({ ...obj, [filter]: true }), {});
   if (filters.length) {

--- a/src/data/redux/hooks.js
+++ b/src/data/redux/hooks.js
@@ -6,6 +6,7 @@ import requestSelectors from './requests/selectors';
 
 const { courseCard } = appSelectors;
 
+export const usePageNumber = () => useSelector(appSelectors.pageNumber);
 export const useEmailConfirmationData = () => useSelector(appSelectors.emailConfirmation);
 export const useEnterpriseDashboardData = () => useSelector(appSelectors.enterpriseDashboard);
 export const usePlatformSettingsData = () => useSelector(appSelectors.platformSettings);

--- a/src/data/redux/thunkActions/app.js
+++ b/src/data/redux/thunkActions/app.js
@@ -11,25 +11,25 @@ import requests from './requests';
 // import { } from './requests';
 import * as module from './app';
 
+export const loadData = ({ courses, ...globalData }) => dispatch => {
+  dispatch(actions.app.setPageNumber(1));
+  dispatch(actions.app.loadGlobalData(globalData));
+  dispatch(actions.app.loadCourses({ courses }));
+};
+
 /**
  * initialize the app, loading ora and course metadata from the api, and loading the initial
  * submission list data.
  */
 export const initialize = () => (dispatch) => (
   dispatch(requests.initializeList({
-    onSuccess: (({ courses, ...globalData }) => {
-      dispatch(actions.app.loadGlobalData(globalData));
-      dispatch(actions.app.loadCourses({ courses }));
-    }),
+    onSuccess: (response) => dispatch(module.loadData(response)),
   }))
 );
 
 export const refreshList = () => (dispatch) => (
   dispatch(requests.initializeList({
-    onSuccess: (({ courses, ...globalData }) => {
-      dispatch(actions.app.loadGlobalData(globalData));
-      dispatch(actions.app.loadCourses({ courses }));
-    }),
+    onSuccess: (response) => dispatch(module.loadData(response)),
   }))
 );
 
@@ -95,6 +95,7 @@ export const clearMasquerade = () => (dispatch) => {
 };
 
 export default StrictDict({
+  loadData,
   initialize,
   refreshList,
   sendConfirmEmail,

--- a/src/data/services/lms/fakeData/courses.js
+++ b/src/data/services/lms/fakeData/courses.js
@@ -25,6 +25,25 @@ export const relatedPrograms = [
     programTypeUrl: 'www.edx/my-program-type',
     numberOfCourses: 3,
   },
+  {
+    provider: 'HarvardX',
+    bannerImgSrc: 'https://prod-discovery.edx-cdn.org/media/course/image/327c8e4f-315a-417b-9857-046dfc90c243-677b97464958.small.jpg',
+    logoImgSrc: 'https://prod-discovery.edx-cdn.org/organization/certificate_logos/44022f13-20df-4666-9111-cede3e5dc5b6-770e00385e7e.png',
+    title: 'Relativity in Modern Mechanics',
+    programUrl: 'www.edx/my-program-3',
+    programType: 'MicroBachelors Program',
+    numberOfCourses: 3,
+  },
+  {
+    provider: 'University  of Maryland',
+    bannerImgSrc: 'https://prod-discovery.edx-cdn.org/media/programs/banner_images/9a310b98-8f27-439e-be85-12d6460245c9-f2efca129273.small.jpg',
+    logoImgSrc: 'https://prod-discovery.edx-cdn.org/organization/certificate_logos/b9dc96da-b3fc-45a6-b6b7-b8e12eb79335-ac60112330e3.png',
+    title: 'Pandering for Modern Professionals',
+    programUrl: 'www.edx/my-program-4',
+    programType: 'MicroBachelors Program',
+    programTypeUrl: 'www.edx/my-program-type',
+    numberOfCourses: 3,
+  },
 ];
 
 export const genCardId = (index) => `card-id${index}`;
@@ -62,7 +81,7 @@ const globalData = {
     },
     {
       bannerImgSrc: 'https://prod-discovery.edx-cdn.org/media/programs/banner_images/9a310b98-8f27-439e-be85-12d6460245c9-f2efca129273.small.jpg',
-      courseName: 'Suggested course 2',
+      courseName: 'Suggested course 2 with a really really really long name for some reason',
       courseUrl: 'www.edx/suggested-course',
     },
     {
@@ -699,14 +718,6 @@ export const entitlementData = entitlementCourses.map(
     };
   },
 );
-
-console.log('%j', {
-  courses: [
-    ...courseRunData,
-    ...entitlementData,
-  ],
-  ...globalData,
-});
 
 export default {
   courseRunData,

--- a/src/testKeys.js
+++ b/src/testKeys.js
@@ -1,0 +1,13 @@
+import { StrictDict } from 'utils';
+
+export const htmlProps = StrictDict({
+  disabled: 'disabled',
+  href: 'href',
+  onClick: 'onClick',
+  onChange: 'onChange',
+  onBlur: 'onBlur',
+});
+
+export default {
+  htmlProps,
+};


### PR DESCRIPTION
updates mock methods to allow forcing empty course list `loadEmptyData()`
fixes course action location to bottom of card
makes related program cards clickable
makes related programs modal scrollable
reset pagination on initialize/refresh list.

https://docs.google.com/document/d/1tBesg2CuIGeIZJ3Gvk9BFrQfyT3DjJLCU53g3181NAQ/edit#

![image](https://user-images.githubusercontent.com/5533134/192634194-1130a849-e4f8-4734-8361-8e1154d80454.png)
![image](https://user-images.githubusercontent.com/5533134/192634244-ce197ae8-cdf0-4bfc-9028-e35d8bb5b747.png)
