### PR TITLE
fix: update transfex flag for tx cli 1.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ push_translations:
 
 # Pulls translations from Transifex.
 pull_translations:
-	tx pull -f --mode reviewed --languages=$(transifex_langs)
+	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
 
 # This target is used by CI.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
The Transifex cli started requiring the -t or --translations flag in the pull command in order to fetch translations.

https://github.com/transifex/cli/pull/96