### PR TITLE
chore: fix typo for selection button

### DIFF
--- a/src/containers/CourseCard/components/CourseCardActions/SelectSessionButton.jsx
+++ b/src/containers/CourseCard/components/CourseCardActions/SelectSessionButton.jsx
@@ -20,7 +20,7 @@ export const SelectSessionButton = ({ cardId }) => {
       disabled={isMasquerading || !hasAccess || (!canChange || !hasSessions)}
       onClick={openSessionModal}
     >
-      {formatMessage(messages.resume)}
+      {formatMessage(messages.selectSession)}
     </Button>
   );
 };

--- a/src/containers/CourseCard/components/CourseCardActions/__snapshots__/SelectSessionButton.test.jsx.snap
+++ b/src/containers/CourseCard/components/CourseCardActions/__snapshots__/SelectSessionButton.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`SelectSessionButton snapshot renders default button 1`] = `
   disabled={false}
   onClick={[MockFunction mockOpenSessionModal]}
 >
-  Resume
+  Select Session
 </Button>
 `;
 
@@ -14,7 +14,7 @@ exports[`SelectSessionButton snapshot renders disabled button if masquerading 1`
   disabled={true}
   onClick={[MockFunction mockOpenSessionModal]}
 >
-  Resume
+  Select Session
 </Button>
 `;
 
@@ -23,6 +23,6 @@ exports[`SelectSessionButton snapshot renders disabled button when user does not
   disabled={true}
   onClick={[MockFunction mockOpenSessionModal]}
 >
-  Resume
+  Select Session
 </Button>
 `;


### PR DESCRIPTION
Fix button label for "Select Entitlements" modal. Should be "Select Session" instead of "Resume".