### PR TITLE
fix: select and leave session to match the backend

### DIFF
--- a/src/data/redux/thunkActions/app.js
+++ b/src/data/redux/thunkActions/app.js
@@ -55,12 +55,12 @@ export const switchEntitlementEnrollment = (cardId, selection) => (dispatch, get
 
 export const leaveEntitlementSession = (cardId) => (dispatch, getState) => {
   const { courseId } = selectors.app.courseCard.courseRun(getState(), cardId);
-  const { uuid } = selectors.app.courseCard.entitlement(getState(), cardId);
-  handleEvent(eventNames.entitlementUnenroll({ action: 'leave' }), {
-    fromCourseRun: courseId,
-    toCourseRun: null,
+  const { uuid, isRefundable } = selectors.app.courseCard.entitlement(getState(), cardId);
+  handleEvent(eventNames.entitlementUnenroll, {
+    leaveCourseRun: courseId,
+    isRefundable,
   });
-  dispatch(requests.leaveEntitlementSession({ uuid }));
+  dispatch(requests.leaveEntitlementSession({ uuid, isRefundable }));
   dispatch(initialize());
 };
 

--- a/src/data/redux/thunkActions/app.test.js
+++ b/src/data/redux/thunkActions/app.test.js
@@ -9,13 +9,13 @@ import * as module from './app';
 jest.mock('data/services/segment/utils', () => ({
   handleEvent: jest.fn(),
 }));
-jest.mock('data/services/segment/constants', () => ({
-  eventNames: {
-    sessionChange: jest.fn(args => ({ sessionChange: args })),
-    entitlementUnenroll: jest.fn(args => ({ entitlementUnenroll: args })),
-    unenrollReason: 'unenroll-reason',
-  },
-}));
+// jest.mock('data/services/segment/constants', () => ({
+//   eventNames: {
+//     sessionChange: jest.fn(args => ({ sessionChange: args })),
+//     entitlementUnenroll: 'entitlement-unenroll',
+//     unenrollReason: 'unenroll-reason',
+//   },
+// }));
 jest.mock('data/services/lms/utils', () => ({
   post: jest.fn(),
 }));
@@ -59,6 +59,7 @@ const uuid = 'test-UUID';
 const cardId = 'test-card-id';
 const selection = 'test-selection';
 const courseId = 'test-COURSE-id';
+const isRefundable = 'test-is-refundable';
 
 const loadDataSpy = jest.spyOn(module, moduleKeys.loadData);
 const mockLoadData = data => ({ loadData: data });
@@ -73,7 +74,7 @@ describe('app thunk actions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     selectors.app.emailConfirmation.mockReturnValueOnce({ sendEmailUrl: testString });
-    selectors.app.courseCard.entitlement.mockReturnValueOnce({ uuid });
+    selectors.app.courseCard.entitlement.mockReturnValueOnce({ uuid, isRefundable });
     selectors.app.courseCard.courseRun.mockReturnValueOnce({ courseId });
   });
   describe('loadData', () => {
@@ -152,12 +153,12 @@ describe('app thunk actions', () => {
       expect(selectors.app.courseCard.courseRun).toHaveBeenCalledWith(testState, cardId);
       expect(selectors.app.courseCard.entitlement).toHaveBeenCalledWith(testState, cardId);
       expect(handleEvent).toHaveBeenCalledWith(
-        eventNames.entitlementUnenroll({ action: 'leave' }),
-        { fromCourseRun: courseId, toCourseRun: null },
+        eventNames.entitlementUnenroll,
+        { leaveCourseRun: courseId, isRefundable },
       );
     });
     it('dispatches leaveEntitlementEnrollment request action', () => {
-      expect(dispatch).toHaveBeenCalledWith(requests.leaveEntitlementSession({ uuid }));
+      expect(dispatch).toHaveBeenCalledWith(requests.leaveEntitlementSession({ uuid, isRefundable }));
     });
   });
   describe('unenrollFromCourse', () => {

--- a/src/data/redux/thunkActions/requests.js
+++ b/src/data/redux/thunkActions/requests.js
@@ -66,9 +66,9 @@ export const switchEntitlementEnrollment = ({
   options,
 });
 
-export const leaveEntitlementSession = ({ uuid, ...options }) => module.networkAction({
+export const leaveEntitlementSession = ({ uuid, isRefundable, ...options }) => module.networkAction({
   requestKey: RequestKeys.leaveEntitlementSession,
-  promise: api.deleteEntitlementEnrollment({ uuid }),
+  promise: api.deleteEntitlementEnrollment({ uuid, isRefundable }),
   options,
 });
 

--- a/src/data/redux/thunkActions/requests.test.js
+++ b/src/data/redux/thunkActions/requests.test.js
@@ -42,6 +42,7 @@ const promise = 'test-promise';
 const requestKey = 'test-request-key';
 const user = 'test-user';
 const uuid = 'test-uuid';
+const isRefundable = 'test-is-refundable';
 
 describe('requests thunkActions module', () => {
   beforeEach(jest.clearAllMocks);
@@ -170,10 +171,10 @@ describe('requests thunkActions module', () => {
 
     describe('leaveEntitlementSession', () => {
       it('dispatches leaveEntitlementSession networkAction', () => {
-        expect(module.leaveEntitlementSession({ uuid, ...options })).toEqual(
+        expect(module.leaveEntitlementSession({ uuid, isRefundable, ...options })).toEqual(
           mockNetworkAction({
             requestKey: RequestKeys.leaveEntitlementSession,
-            promise: api.deleteEntitlementEnrollment({ uuid }),
+            promise: api.deleteEntitlementEnrollment({ uuid, isRefundable }),
             options,
           }),
         );

--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -19,14 +19,14 @@ const initializeList = ({ user } = {}) => get(stringifyUrl(
   { [apiKeys.user]: user },
 ));
 
-const updateEntitlementEnrollment = ({ uuid, courseId }) => post(stringifyUrl(
+const updateEntitlementEnrollment = ({ uuid, courseId }) => post(
   urls.entitlementEnrollment(uuid),
   { [apiKeys.courseRunId]: courseId },
-));
+);
 
-const deleteEntitlementEnrollment = ({ uuid }) => client().delete(stringifyUrl(
+const deleteEntitlementEnrollment = ({ uuid, isRefundable }) => client().delete(stringifyUrl(
   urls.entitlementEnrollment(uuid),
-  { [apiKeys.courseRunId]: null },
+  { [apiKeys.isRefund]: isRefundable },
 ));
 
 const updateEmailSettings = ({ courseId, enable }) => post(

--- a/src/data/services/lms/api.test.js
+++ b/src/data/services/lms/api.test.js
@@ -21,6 +21,7 @@ jest.mock('./utils', () => {
 const testUser = 'test-user';
 const testUuid = 'test-UUID';
 const testCourseId = 'TEST-course-ID';
+const isRefundable = 'test-is-refundable';
 
 describe('lms api methods', () => {
   describe('initializeList', () => {
@@ -38,21 +39,21 @@ describe('lms api methods', () => {
       expect(
         api.updateEntitlementEnrollment({ uuid: testUuid, courseId: testCourseId }),
       ).toEqual(
-        utils.post(utils.stringifyUrl(
+        utils.post(
           urls.entitlementEnrollment(testUuid),
           { [apiKeys.courseRunId]: testCourseId },
-        )),
+        ),
       );
     });
   });
   describe('deleteEntitlementEnrollment', () => {
     it('calls delete on entitlementEnrollment url with uuid and null course run ID', () => {
       expect(
-        api.deleteEntitlementEnrollment({ uuid: testUuid }),
+        api.deleteEntitlementEnrollment({ uuid: testUuid, isRefundable }),
       ).toEqual(
         utils.client().delete(utils.stringifyUrl(
           urls.entitlementEnrollment(testUuid),
-          { [apiKeys.courseRunId]: null },
+          { [apiKeys.isRefund]: isRefundable },
         )),
       );
     });

--- a/src/data/services/lms/constants.js
+++ b/src/data/services/lms/constants.js
@@ -6,6 +6,7 @@ export const apiKeys = StrictDict({
   courseRunId: 'course_run_id',
   courseId: 'course_id',
   user: 'user',
+  isRefund: 'is_refund',
 });
 
 export const apiValues = StrictDict({


### PR DESCRIPTION
what change:
- post `${api}/entitlements/v1/entitlements/${uuid}/enrollments` expect a body instead of params and it must include `course_run_id`
- delete `${api}/entitlements/v1/entitlements/${uuid}/enrollments` expect a params of `is_refund`.

The existing bff file for this `api` is in `common/djangoapps/entitlements/rest_api/v1/views.py::EntitlementEnrollmentViewSet`