### PR TITLE
fix: check for null courserun in done filter

### DIFF
--- a/src/data/redux/app/selectors/currentList.js
+++ b/src/data/redux/app/selectors/currentList.js
@@ -12,7 +12,7 @@ export const sortFn = (transform, { reverse }) => (v1, v2) => {
 
 export const courseFilters = StrictDict({
   [FilterKeys.notEnrolled]: (course) => !course.enrollment.isEnrolled,
-  [FilterKeys.done]: (course) => course.courseRun.isArchived,
+  [FilterKeys.done]: (course) => course.courseRun && course.courseRun.isArchived,
   [FilterKeys.upgraded]: (course) => course.enrollment.isVerified,
   [FilterKeys.inProgress]: (course) => course.enrollment.hasStarted,
   [FilterKeys.notStarted]: (course) => !course.enrollment.hasStarted,

--- a/src/data/redux/app/selectors/currentList.test.js
+++ b/src/data/redux/app/selectors/currentList.test.js
@@ -49,6 +49,7 @@ describe('courseList selector module', () => {
         filterFn = courseFilters[FilterKeys.done];
         expect(filterFn({ courseRun: { isArchived: true } })).toEqual(true);
         expect(filterFn({ courseRun: { isArchived: false } })).toEqual(false);
+        expect(filterFn({ courseRun: null })).toEqual(false);
       });
       test('upgraded returns true if learner is verified', () => {
         filterFn = courseFilters[FilterKeys.upgraded];


### PR DESCRIPTION
Unfulfilled entitlements have a `null` `courseRun`. We check `courseRun.isArchived` for the done filter, which causes an exception when we try to read `isArchived` from `null`. Add something to catch a null `courseRun`

https://2u-internal.atlassian.net/browse/AU-919