### PR TITLE
fix: alignment issue between enrolled and recommended courses section

### DIFF
--- a/src/containers/Dashboard/index.scss
+++ b/src/containers/Dashboard/index.scss
@@ -2,7 +2,6 @@
 
 .course-list-column {
   padding: 0 map-get($spacers, 4);
-  margin: auto;
 }
 
 .sidebar-column {


### PR DESCRIPTION
This PR fixes the vertical alignment issue between the enrolled courses section and recommended courses section when the number of enrolled courses is either 1 or 2. 

**Expected Figma Design:**

<img width="1680" alt="Screenshot 2022-11-30 at 4 50 01 PM" src="https://user-images.githubusercontent.com/52817156/204789899-d809a02e-f929-475c-bc88-ba9d2835e106.png">

**Before:**

with 1 enrolled course:

<img width="1680" alt="Screenshot 2022-11-30 at 1 21 15 PM" src="https://user-images.githubusercontent.com/52817156/204790056-008b6965-32d8-4a9c-bb5b-67ada423ddcc.png">

with 2 enrolled courses:

<img width="1680" alt="Screenshot 2022-11-30 at 1 22 00 PM" src="https://user-images.githubusercontent.com/52817156/204790092-43a09150-607d-4ce8-a1e4-29cace507112.png">

**After:**

with 1 enrolled course:

<img width="1680" alt="Screenshot 2022-11-30 at 1 26 21 PM" src="https://user-images.githubusercontent.com/52817156/204790126-7cfc5a63-dbec-473c-914e-717b53170881.png">

with 2 enrolled courses:

<img width="1680" alt="Screenshot 2022-11-30 at 1 25 57 PM" src="https://user-images.githubusercontent.com/52817156/204790176-28bab2b4-b1a7-4fa0-9946-8bf81afc1c2e.png">
